### PR TITLE
Broaden directory & file requirements in validation.

### DIFF
--- a/lib/android_img_resizer/android_img_resizer.rb
+++ b/lib/android_img_resizer/android_img_resizer.rb
@@ -6,17 +6,8 @@ module AndroidImgResizer
   class AndroidImgResizer	
 	 
   def AndroidImgResizer.verify_android_project
-  	files=["AndroidManifest.xml"]
-  	directories=["res","res/drawable-hdpi","res/drawable-mdpi","res/drawable-ldpi","src"]
+  	directories=["res","res/drawable-hdpi","res/drawable-mdpi","res/drawable-ldpi"]
 	
-    files.each do |file|
-      if !File::exists?(file)
-        puts "Error: This is not a Android project Directory"
-        puts "Error: File not exists"+file
-        return false
-      end
-    end
-
     directories.each do |directory|
       if  !File::directory?(directory)
         puts "Error: This is not a Android project Directory"


### PR DESCRIPTION
With Android Studio/Gradle's project & flavor structure, a manifest file and src
directory may not necessarily exist. Running android_img_resizer in a specific flavor directory refused to resize the image in my product flavors with this structure:

```
MyProject/
 +-- build.gradle
 +-- src/
 |    |
 |    +-- main/
 |    +-- AndroidManifest.xml
 |    |    +-- java/
 |    |    +-- res/
 |    |    |    +-- drawable/
 |    |    |    +-- drawable-mdpi/
 |    |    |    +-- drawable-hdpi/
 |    |    |    +-- drawable-xhdpi/
 |    |
 |    +-- flavor1/
 |    |    +--res/
 |    |    |    +-- drawable/
 |    |    |    +-- drawable-mdpi/
 |    |    |    +-- drawable-hdpi/
 |    |    |    +-- drawable-xhdpi/
 |    |
 |    +-- flavor2/
 |    |    +-- res/
 |    |    |    +-- drawable/
 |    |    |    +-- drawable-mdpi/
 |    |    |    +-- drawable-hdpi/
 |    |    |    +-- drawable-xhdpi/
```
